### PR TITLE
Read last check result directly from the object

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -137,7 +137,6 @@ func main() {
 	r.Get("/icinga/dynamic_text/{host-name}", handleIcingaVars)
 	r.Get("/icinga/{check-type}/{object-id}", handleIcingaCheck)
 	r.Get("/icinga/check_state", handleIcingaCheckState)
-	r.Get("/icinga/check_result", handleCheckResult)
 
 	// find and return dashboard json (useful for debugging),
 	// e.g. GET /template?templateid=ha.json

--- a/frontend/src/meerkat.js
+++ b/frontend/src/meerkat.js
@@ -34,16 +34,12 @@ export async function getIcingaObjectState(objectType, filter, dashboard) {
 	);
 }
 
-export async function getCheckResult(
-	objType,
-	object,
-	attrs = "last_check_result"
-) {
-	return fetchHandler(
-		`/icinga/check_result?objtype=${objType}&object=${encodeURIComponent(
-			object
-		)}&attrs=${encodeURIComponent(attrs)}`
-	);
+export async function getCheckResult(objType, objName) {
+	if (objType == "host") {
+		return fetchHandler(`/icinga/hosts/${encodeURIComponent(objName)}`);
+	} else if (objType == "service") {
+		return fetchHandler(`/icinga/services/${encodeURIComponent(objName)}`);
+	}
 }
 
 export async function getDashboard(slug) {

--- a/frontend/src/util.jsx
+++ b/frontend/src/util.jsx
@@ -430,7 +430,7 @@ export function getCheckData(options, callback) {
 
 		// extract & transform performance data
 		let perfData = c.results
-			? c.results[0].attrs.last_check_result.performance_data
+			? c.results[0].lastCheckResult.performance_data
 			: null;
 		if (
 			perfData !== null &&
@@ -449,7 +449,7 @@ export function getCheckData(options, callback) {
 		}
 
 		checkData.pluginOutput = c.results
-			? c.results[0].attrs.last_check_result.output
+			? c.results[0].lastCheckResult.output
 			: null;
 
 		callback(checkData);


### PR DESCRIPTION
There's no need for an entirely separate cache, functions, types,
backend HTTP endpoints just to store last check result data. In
Icinga, a check result lives with a host/service. Now when the
frontend wants the last check result of a host/service, it fetches the
object then reads its last check result field.

Raised from #62 