### PR TITLE
backend: require authentication to edit dashboards if set

### DIFF
--- a/config/meerkat.toml.example
+++ b/config/meerkat.toml.example
@@ -7,3 +7,8 @@ IcingaUsername = "api-user"
 IcingaPassword = "api-password"
 # Set to true when, for example, Icinga serves a self-signed certificate.
 IcingaInsecureTLS = false
+
+# If set, editing dashboards requires authenticating as this username and password
+# using HTTP Basic Authentication.
+# AdminUsername = "admin"
+# AdminPassword = "password"


### PR DESCRIPTION
This is a bare minimum implementation. You can
set one username password pair in the configuration file, then any
attempt to edit a dashboard must first go through HTTP Basic
Authentication with those credentials. No support for more than one
set of credentials. I'm not entirely convinced that this application
needs to be run on a server connected to the network anyway.

A later change could render the homepage differently based on whether
it has successfully authenticated. For example, render on the "View"
and not "Edit" or "Delete" dashboard buttons.

See #31