### PR TITLE
frontend, backend: only show edit, delete dashboard when authenticated

### DIFF
--- a/backend/auth.go
+++ b/backend/auth.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"bytes"
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+const cookieName string = "meerkat"
+
+type tokenStore map[token]time.Time
+
+func (store tokenStore) authenticate(tok string) (success bool) {
+	for k := range store {
+		if token(tok) == k {
+			return true
+		}
+	}
+	return false
+}
+
+func newTokenStore() tokenStore {
+	return make(map[token]time.Time)
+}
+
+type token string
+
+func newToken() (token, error) {
+	s, err := randomString(32)
+	if err != nil {
+		return "", err
+	}
+	return token(s), nil
+}
+
+func randomString(n int) (string, error) {
+	buf := &bytes.Buffer{}
+	encoder := base64.NewEncoder(base64.StdEncoding, buf)
+	b, err := randomBytes(n)
+	if err != nil {
+		return "", err
+	}
+	encoder.Write(b)
+	encoder.Close()
+	return buf.String(), nil
+}
+
+func randomBytes(n int) ([]byte, error) {
+	b := make([]byte, n)
+	_, err := rand.Read(b)
+	if err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+// basicAuthHandler returns a http.Handler which presents a HTTP Basic Authentication challenge
+// before the request can proceed. The challenge must be completed with the provided
+// username and password.
+// Alternatively, a Cookie may be sent containing a token from a previous successful authentication.
+// On successful authentication, a Cookie is returned and the request is handled by next.
+func basicAuthHandler(username, password string, store tokenStore, next http.Handler) http.Handler {
+	fn := func(w http.ResponseWriter, req *http.Request) {
+		cookie, err := req.Cookie(cookieName)
+		if errors.Is(err, http.ErrNoCookie) {
+			// continue to basic auth
+		} else if err != nil {
+			code := http.StatusBadRequest
+			http.Error(w, http.StatusText(code), code)
+			return
+		}
+		if cookie != nil {
+			if store.authenticate(cookie.Value) {
+				next.ServeHTTP(w, req)
+				return
+			}
+		}
+
+		u, p, ok := req.BasicAuth()
+		if !ok || len(u) == 0 || len(p) == 0 {
+			w.Header().Set("WWW-Authenticate", `Basic realm="meerkat"`)
+			c := http.StatusUnauthorized
+			http.Error(w, http.StatusText(c), c)
+			return
+		}
+		if u == username && p == password {
+			token, err := newToken()
+			if err != nil {
+				msg := fmt.Sprintf("create new auth token: %v", err)
+				http.Error(w, msg, http.StatusInternalServerError)
+				return
+			}
+			store[token] = time.Now()
+			cookie := &http.Cookie{
+				Name:  cookieName,
+				Value: string(token),
+			}
+			http.SetCookie(w, cookie)
+
+			next.ServeHTTP(w, req)
+			return
+		}
+		w.Header().Set("WWW-Authenticate", `Basic realm="meerkat"`)
+		c := http.StatusUnauthorized
+		http.Error(w, http.StatusText(c), c)
+	}
+	return http.HandlerFunc(fn)
+}
+
+func emptyHandler(w http.ResponseWriter, req *http.Request) {
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/backend/dashboard.go
+++ b/backend/dashboard.go
@@ -213,29 +213,6 @@ type SlugResponse struct {
 	Slug string `json:"slug"`
 }
 
-// basicAuthHandler returns a http.Handler which presents a HTTP Basic Authentication challenge
-// before the request can proceed. The challenge must be completed with the provided
-// username and password. On successful authentication, the request is handled by next.
-func basicAuthHandler(username, password string, next http.Handler) http.Handler {
-	fn := func(w http.ResponseWriter, req *http.Request) {
-		u, p, ok := req.BasicAuth()
-		if !ok || len(u) == 0 || len(p) == 0 {
-			w.Header().Set("WWW-Authenticate", `Basic realm="meerkat"`)
-			c := http.StatusUnauthorized
-			http.Error(w, http.StatusText(c), c)
-			return
-		}
-		if u == username && p == password {
-			next.ServeHTTP(w, req)
-			return
-		}
-		w.Header().Set("WWW-Authenticate", `Basic realm="meerkat"`)
-		c := http.StatusUnauthorized
-		http.Error(w, http.StatusText(c), c)
-	}
-	return http.HandlerFunc(fn)
-}
-
 func handleCreateDashboard(w http.ResponseWriter, r *http.Request) {
 	//Decode body
 	buf := new(bytes.Buffer)

--- a/frontend/src/home.jsx
+++ b/frontend/src/home.jsx
@@ -356,6 +356,17 @@ function DashboardList({ dashboards, loadDashboards, filter }) {
 
 	const dbs = filteredDashboards.map((dashboard) => {
 		const slug = titleToSlug(dashboard.title);
+		if (meerkat.authConfigured() && document.cookie == "") {
+			return (
+				<div class="dashboard-listing">
+					<h3>{dashboard.title}</h3>
+					<div class="timestamps">
+						<a href={`/view/${slug}`}>view</a>
+						<TemplateModal slug={slug} />
+					</div>
+				</div>
+			);
+		}
 		return (
 			<div class="dashboard-listing">
 				<h3>{dashboard.title}</h3>

--- a/frontend/src/meerkat.js
+++ b/frontend/src/meerkat.js
@@ -116,3 +116,17 @@ export async function uploadFile(file) {
 	});
 	return res.json();
 }
+
+export async function authConfigured() {
+	const res = await fetch("/authentication", {
+		method: "HEAD",
+	});
+	if (res.status == 404) {
+		return false;
+	}
+	return true;
+}
+
+export async function authenticate() {
+	return await fetch("/authenticate");
+}


### PR DESCRIPTION
This works by first testing if authentication is configured on the server.
If so, authenticating to the server results in a cookie being returned.
The presence of a cookie changes how the dashboard list is rendered.

Cookies are generated by the server by creating "tokens": base64-encoded random bytes.
Tokens are only held in-process in memory.

I don't know how to create a "log in" button to prompt authentication
A <button> element which has its onClick attribute set to
meerkat.authenticate() may do the trick.

Closes #96