### PR TITLE
frontend: remove unused inner-text css class

### DIFF
--- a/frontend/style.css
+++ b/frontend/style.css
@@ -930,14 +930,6 @@ div.tag .close-icon {
 	align-items: center;
 }
 
-.inner-text {
-	text-transform: none;
-	word-wrap: break-word;
-	white-space: initial;
-	width: 100%;
-	height: 100%;
-}
-
 a#a-link {
 	display: block;
 	line-height: 0;


### PR DESCRIPTION
This is unfinished work that likely got accidentally committed. It's
from a stale branch which contained 1 commit, whose message was just
"Text case as typed. wraps around box."