### PR TITLE
Add script for creating a meerkat tarball

### DIFF
--- a/mkdist.sh
+++ b/mkdist.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+
+# Creates a distribution tarball in a temporary directory from source.
+# The path to the created tarball is the last line of the script's
+# output.
+
+( cd backend && go build )
+
+(
+	cd frontend
+	npm ci
+	npm run build
+)
+
+tmp=`mktemp -d`
+dir="$tmp/meerkat"
+mkdir -p $dir
+
+cp README.md LICENSE $dir
+cp -R dashboards-data $dir
+cp Dockerfile $dir
+cp -R contrib $dir
+cp -R docs $dir
+
+cp config/meerkat.toml.example $dir
+cp backend/meerkat $dir
+
+mkdir -p "$dir/frontend"
+cp -R frontend/index.html frontend/style.css frontend/res frontend/assets "$dir/frontend"
+cp -R frontend/react-widgets.css frontend/fonts "$dir/frontend"
+cp -R frontend/dist "$dir/frontend"
+
+tarball="$tmp/meerkat.tar.gz"
+cd "$tmp"
+tar cv meerkat | gzip -c > "$tarball"
+echo "$tarball"


### PR DESCRIPTION
Creates a distribution tarball in a temporary directory from source.
The path to the created tarball is the last line of the script's
output.

This is part of the way to getting to a debian package or container
image etc.. We can publish the tarball as a thing to download in a
github release thing.
