### PR TITLE
Bug fixes for v3.0.4 and monitoring

### DIFF
--- a/cmd/meerkat/dashboard.go
+++ b/cmd/meerkat/dashboard.go
@@ -155,7 +155,9 @@ func handleCloneDashboard(w http.ResponseWriter, req *http.Request) {
 	}
 	dest := src
 	dest.Title = req.PostForm.Get("title")
+	dest.Slug = strings.ReplaceAll(dest.Title, " ", "-")
 	destPath := path.Join("dashboards", dest.Slug+".json")
+
 	if err := meerkat.CreateDashboard(destPath, &dest); err != nil {
 		msg := fmt.Sprintf("create dashboard from %s: %v", srcPath, err)
 		log.Println(msg)

--- a/cmd/meerkat/dashboard.go
+++ b/cmd/meerkat/dashboard.go
@@ -50,9 +50,9 @@ type Status struct {
 					RecentHistory      []Requests `json:"recent_history"`
 				} `json:"api_calls"`
 				EventStreams struct {
-					LastEventReceived int      `json:"last_event_received"`
-					ReceivedEventCount  int      `json:"received_count_1min"`
-					RecentHistory     []Events `json:"recent_history"`
+					LastEventReceived  int      `json:"last_event_received"`
+					ReceivedEventCount int      `json:"received_count_1min"`
+					RecentHistory      []Events `json:"recent_history"`
 				} `json:"event_streams"`
 			} `json:"connections"`
 		} `json:"icinga"`

--- a/cmd/meerkat/dashboard.go
+++ b/cmd/meerkat/dashboard.go
@@ -51,7 +51,7 @@ type Status struct {
 				} `json:"api_calls"`
 				EventStreams struct {
 					LastEventReceived int      `json:"last_event_received"`
-					RecentEventCount  int      `json:"recent_event_count"`
+					ReceivedEventCount  int      `json:"received_count_1min"`
 					RecentHistory     []Events `json:"recent_history"`
 				} `json:"event_streams"`
 			} `json:"connections"`
@@ -365,7 +365,7 @@ func getStatusHandler(w http.ResponseWriter, r *http.Request) {
 	status.Backends.Icinga.Connections.APICalls.RecentHistory = requestList
 
 	events := getEvents()
-	status.Backends.Icinga.Connections.EventStreams.RecentEventCount = len(events)
+	status.Backends.Icinga.Connections.EventStreams.ReceivedEventCount = len(events)
 	status.Backends.Icinga.Connections.EventStreams.RecentHistory = events
 
 	body, err := json.Marshal(status)

--- a/cmd/meerkat/dashboard.go
+++ b/cmd/meerkat/dashboard.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"crypto/tls"
 	"encoding/json"
 	"errors"
@@ -18,11 +19,45 @@ import (
 	"path"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/meerkat-dashboard/meerkat"
 	"github.com/r3labs/sse/v2"
 )
+
+type Requests struct {
+	CallMade   string `json:"call_made"`
+	CallTime   int64  `json:"call_time"`
+	Dashboard  string `json:"dashboard"`
+	StatusCode int    `json:"status_code"`
+}
+
+type Status struct {
+	Meerkat struct {
+		StartTime  int64 `json:"start_time"`
+		Dashboards struct {
+		} `json:"dashboards"`
+	} `json:"meerkat"`
+	Backends struct {
+		Icinga struct {
+			Type          string `json:"type"`
+			Status        string `json:"status"`
+			StatusMessage string `json:"status_message"`
+			Connections   struct {
+				APICalls struct {
+					RecentRequestCount int        `json:"recent_request_count"`
+					RecentHistory      []Requests `json:"recent_history"`
+				} `json:"api_calls"`
+				EventStreams struct {
+					LastEventRecieved int      `json:"last_event_recieved"`
+					RecentEventCount  int      `json:"recent_event_count"`
+					RecentHistory     []Events `json:"recent_history"`
+				} `json:"event_streams"`
+			} `json:"connections"`
+		} `json:"icinga"`
+	} `json:"backends"`
+}
 
 func UpdateHandler(w http.ResponseWriter, req *http.Request) {
 	if req.Method != http.MethodGet {
@@ -40,6 +75,7 @@ func SetWorking() {
 	server.Publish("updates", &sse.Event{
 		Data: []byte("icinga-success"),
 	})
+	status.Backends.Icinga.Status = "working"
 }
 
 func UpdateAll() {
@@ -54,6 +90,7 @@ func SendError() {
 	server.Publish("updates", &sse.Event{
 		Data: []byte("icinga-error"),
 	})
+	status.Backends.Icinga.Status = "failed"
 }
 
 func SendHeartbeat() {
@@ -321,6 +358,28 @@ func handleError(w http.ResponseWriter, dec *json.Decoder, dashboardTitle string
 	w.Write(b)
 }
 
+func getStatusHandler(w http.ResponseWriter, r *http.Request) {
+	status.Backends.Icinga.Connections.APICalls.RecentRequestCount = len(requestList)
+	status.Backends.Icinga.Connections.APICalls.RecentHistory = requestList
+
+	events := getEvents()
+	status.Backends.Icinga.Connections.EventStreams.RecentEventCount = len(events)
+	status.Backends.Icinga.Connections.EventStreams.RecentHistory = events
+
+	body, err := json.Marshal(status)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+
+	if _, err := io.Copy(w, bytes.NewReader(body)); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+}
+
 func getAllHandler(w http.ResponseWriter, r *http.Request) {
 	objectType := r.URL.Query().Get("type")
 	dashboardTitle := r.URL.Query().Get("title")
@@ -370,6 +429,14 @@ type StatusCheck struct {
 	} `json:"results"`
 }
 
+func addRequest(request Requests) {
+	if len(requestList) >= 100 {
+		requestList = requestList[1:]
+	}
+
+	requestList = append(requestList, request)
+}
+
 func icingaRequest(apiPath string, dashboardTitle string) (*http.Response, error) {
 	client := &http.Client{}
 	if config.IcingaInsecureTLS {
@@ -396,14 +463,19 @@ func icingaRequest(apiPath string, dashboardTitle string) (*http.Response, error
 	req.SetBasicAuth(config.IcingaUsername, config.IcingaPassword)
 	if err != nil {
 		log.Println("Failed to create request: %w", err)
+		addRequest(Requests{CallMade: apiPath, CallTime: time.Now().UnixMilli(), Dashboard: dashboardTitle, StatusCode: 0})
 		return nil, err
 	}
 
 	res, err := client.Do(req)
+
 	if err != nil {
 		log.Println("Icinga2 API error: %w", err)
+		addRequest(Requests{CallMade: apiPath, CallTime: time.Now().UnixMilli(), Dashboard: dashboardTitle, StatusCode: 0})
 		return nil, err
 	}
+
+	addRequest(Requests{CallMade: apiPath, CallTime: time.Now().UnixMilli(), Dashboard: dashboardTitle, StatusCode: res.StatusCode})
 
 	return res, nil
 }

--- a/cmd/meerkat/dashboard.go
+++ b/cmd/meerkat/dashboard.go
@@ -50,7 +50,7 @@ type Status struct {
 					RecentHistory      []Requests `json:"recent_history"`
 				} `json:"api_calls"`
 				EventStreams struct {
-					LastEventRecieved int      `json:"last_event_recieved"`
+					LastEventReceived int      `json:"last_event_received"`
 					RecentEventCount  int      `json:"recent_event_count"`
 					RecentHistory     []Events `json:"recent_history"`
 				} `json:"event_streams"`

--- a/cmd/meerkat/main.go
+++ b/cmd/meerkat/main.go
@@ -236,7 +236,7 @@ func main() {
 								Event: []byte(event.Type),
 								Data:  []byte(name),
 							})
-							status.Backends.Icinga.Connections.EventStreams.LastEventRecieved = int(time.Now().UnixMilli())
+							status.Backends.Icinga.Connections.EventStreams.LastEventReceived = int(time.Now().UnixMilli())
 							addEvent(name, event.Type)
 						case <-time.After(time.Duration(config.IcingaEventTimeout) * time.Second):
 							log.Printf("Event stream timed out.\n")

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 require github.com/meerkat-dashboard/icinga-go v1.0.2
 
 require (
-	github.com/r3labs/sse/v2 v2.10.0 // indirect
+	github.com/r3labs/sse/v2 v2.10.0
 	golang.org/x/net v0.0.0-20191116160921-f9c825593386 // indirect
 	gopkg.in/cenkalti/backoff.v1 v1.1.0 // indirect
 )

--- a/ui/pages.go
+++ b/ui/pages.go
@@ -308,6 +308,7 @@ func (srv *Server) EditInfoHandler(w http.ResponseWriter, req *http.Request) {
 	}
 
 	dashboard.Title = newdash.Title
+	dashboard.Folder = newdash.Folder
 	dashboard.Background = newdash.Background
 	dashboard.Description = newdash.Description
 	dashboard.GlobalMute = newdash.GlobalMute

--- a/ui/src/editor.jsx
+++ b/ui/src/editor.jsx
@@ -761,5 +761,5 @@ function ElementSettings({ element, updateElement, closeElement }) {
 // Paths are of the form /my-dashboard/view
 const elems = window.location.pathname.split("/");
 const slug = elems[elems.length - 2];
-const events = new EventSource("/icinga/stream");
+const events = new EventSource("/events?stream=icinga");
 render(<Editor slug={slug} events={events} />, document.body);


### PR DESCRIPTION
Fix: Add additional timeout code to Icinga event streams to fix bug where meerkat didn't reconnect to Icinga when Icinga crashed, was still responding then got restarted.
Fix: #207 Dashboard cloning
Fix: #208 Folder allocation
Add `api/status` path which contains information on running meerkat instance for monitoring purposes.
Add monitoring plugin to `contrib` which parses the `api/status`