### PR TITLE
Possible fix for missing state updates

### DIFF
--- a/cmd/meerkat/events.go
+++ b/cmd/meerkat/events.go
@@ -133,6 +133,7 @@ func handleKey(dashboard Dashboard, elementList []ElementStore, name string, eve
 				cache.Set(objectName, req, 1)
 				cache.Wait()
 			} else {
+				found = true
 				value, ok := cache.Get(objectName)
 				if ok {
 					cachedObject := value.(Result)


### PR DESCRIPTION
It looks like if the value was returned from the backend cache, we weren't publishing it onwards to the eventstream